### PR TITLE
Update xtensa and python version

### DIFF
--- a/esp-idf.rb
+++ b/esp-idf.rb
@@ -7,18 +7,17 @@ class EspIdf < Formula
   homepage "https://github.com/espressif/esp-idf"
   url "https://github.com/espressif/esp-idf.git", :using => :git, :branch => :master
   depends_on "xtensa-esp32-elf"
-  # depends_on "pyserial" => :python
-  depends_on :python => ['pyserial']
+  depends_on "python@2" => ['pyserial']
 
   def install
-    ENV.deparallelize 
+    ENV.deparallelize
     # system "git", "submodule", "update", "--init"
 
     # libexec.install Dir["*"]
     prefix.install Dir["*"]
   end
 
-  def caveats; <<-EOS.undent
+  def caveats; <<~EOS
     You may wish to add the ESP-IDF environment (.profile, .bash_profile):
       export IDF_PATH=#{opt_prefix}
     EOS

--- a/esp-idf.rb
+++ b/esp-idf.rb
@@ -5,7 +5,7 @@
 class EspIdf < Formula
   desc "ESP-IDF"
   homepage "https://github.com/espressif/esp-idf"
-  url "https://github.com/espressif/esp-idf.git", :using => :git, :branch => :master
+  url "https://github.com/espressif/esp-idf.git", :using => :git, :branch => "master"
   depends_on "xtensa-esp32-elf"
   depends_on "python@2" => ['pyserial']
 

--- a/xtensa-esp32-elf.rb
+++ b/xtensa-esp32-elf.rb
@@ -5,9 +5,9 @@
 class XtensaEsp32Elf < Formula
   desc "ESP32 toolchain"
   homepage ""
-  url "https://dl.espressif.com/dl/xtensa-esp32-elf-osx-1.22.0-59.tar.gz"
-  version "1.22.0"
-  sha256 "95abdd14b49056ba63981f590f7e54a54b846ab93dc38b81c1f098a240e1599d"
+  url "https://dl.espressif.com/dl/xtensa-esp32-elf-osx-1.22.0-80-g6c4433a-5.2.0.tar.gz"
+  version "1.22.0-80"
+  sha256 "a4307a97945d2f2f2745f415fbe80d727750e19f91f9a1e7e2f8a6065652f9da"
 
   def install
     libexec.install Dir["*"]


### PR DESCRIPTION
This updates the version of the `xtensa` toolchain used in these formulas.

This also updates the deprecated `depends_on :python` statement.